### PR TITLE
Include and install generic kernelspec

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,11 @@
 "%R%" CMD INSTALL --build .
 IF %ERRORLEVEL% NEQ 0 exit 1
+
+mkdir "%PREFIX%\share\jupyter\kernels\juniper"
+IF %ERRORLEVEL% NEQ 0 exit 1
+
+xcopy /f inst\extdata\logo*.png "%PREFIX%\share\jupyter\kernels\juniper\"
+IF %ERRORLEVEL% NEQ 0 exit 1
+
+xcopy /f "%RECIPE_DIR%\kernel.json" "%PREFIX%\share\jupyter\kernels\juniper\"
+IF %ERRORLEVEL% NEQ 0 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,6 +2,13 @@
 if [[ $target_platform =~ linux.* ]] || [[ $target_platform == win-32 ]] || [[ $target_platform == win-64 ]] || [[ $target_platform == osx-64 ]]; then
   export DISABLE_AUTOBREW=1
   $R CMD INSTALL --build .
+
+  # Installs kernelspec with absolute path and R version specific kernel naming:
+  # $R -e 'JuniperKernel::installJuniper(prefix = Sys.getenv("PREFIX"))'
+
+  mkdir -p "$PREFIX/share/jupyter/kernels/juniper"
+  cp -v inst/extdata/logo*.png "$PREFIX/share/jupyter/kernels/juniper/"
+  cp -v "$RECIPE_DIR/kernel.json" "$PREFIX/share/jupyter/kernels/juniper/"
 else
   mkdir -p $PREFIX/lib/R/library/JuniperKernel
   mv * $PREFIX/lib/R/library/JuniperKernel

--- a/recipe/kernel.json
+++ b/recipe/kernel.json
@@ -1,0 +1,5 @@
+{
+  "argv": ["R", "--slave", "-e", "JuniperKernel::bootKernel()", "--args", "{connection_file}"],
+  "display_name": "R (Juniper)",
+  "language": "R"
+}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   merge_build_host: True  # [win]
-  number: 1000
+  number: 1001
   rpaths:
     - lib/R/lib/
     - lib/


### PR DESCRIPTION
This way the juniper kernel is avaiable in Jupyter directly after
installation  of the package (same behavior as r-irkernel).

Other option would be using JuniperKernel::installJuniper and making the
output more generic via sed etc.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
